### PR TITLE
Add @Published behavior to @CloudStorage

### DIFF
--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.pbxproj
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.pbxproj
@@ -1,0 +1,408 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		764AAB632827E82600717087 /* CloudSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764AAB622827E82600717087 /* CloudSettings.swift */; };
+		E20EC87824B0639E006C9FB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20EC87724B0639E006C9FB8 /* AppDelegate.swift */; };
+		E20EC87A24B0639E006C9FB8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20EC87924B0639E006C9FB8 /* SceneDelegate.swift */; };
+		E20EC87C24B0639E006C9FB8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20EC87B24B0639E006C9FB8 /* ContentView.swift */; };
+		E20EC87E24B0639E006C9FB8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E20EC87D24B0639E006C9FB8 /* Assets.xcassets */; };
+		E20EC88124B0639E006C9FB8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E20EC88024B0639E006C9FB8 /* Preview Assets.xcassets */; };
+		E20EC88424B0639E006C9FB8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E20EC88224B0639E006C9FB8 /* LaunchScreen.storyboard */; };
+		E25CFD8A24C2EE5000EBA240 /* MyColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25CFD8924C2EE5000EBA240 /* MyColor.swift */; };
+		E25CFD9024C31F5000EBA240 /* CloudStorage in Frameworks */ = {isa = PBXBuildFile; productRef = E25CFD8F24C31F5000EBA240 /* CloudStorage */; };
+		E25CFD9324C3242D00EBA240 /* CloudStorage+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25CFD9224C3242D00EBA240 /* CloudStorage+Codable.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		764AAB622827E82600717087 /* CloudSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSettings.swift; sourceTree = "<group>"; };
+		E20EC87424B0639E006C9FB8 /* CloudStorage-iOS13.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "CloudStorage-iOS13.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E20EC87724B0639E006C9FB8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E20EC87924B0639E006C9FB8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		E20EC87B24B0639E006C9FB8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		E20EC87D24B0639E006C9FB8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E20EC88024B0639E006C9FB8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		E20EC88324B0639E006C9FB8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E20EC88524B0639E006C9FB8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E22E35F724B212160023F35A /* CloudStorage-iOS13.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "CloudStorage-iOS13.entitlements"; sourceTree = "<group>"; };
+		E25CFD8924C2EE5000EBA240 /* MyColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyColor.swift; sourceTree = "<group>"; };
+		E25CFD8D24C3173E00EBA240 /* CloudStorage */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CloudStorage; path = ../..; sourceTree = "<group>"; };
+		E25CFD9224C3242D00EBA240 /* CloudStorage+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudStorage+Codable.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E20EC87124B0639E006C9FB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E25CFD9024C31F5000EBA240 /* CloudStorage in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E20EC86B24B0639E006C9FB8 = {
+			isa = PBXGroup;
+			children = (
+				E25CFD8D24C3173E00EBA240 /* CloudStorage */,
+				E20EC87624B0639E006C9FB8 /* CloudStorage-iOS13 */,
+				E20EC87524B0639E006C9FB8 /* Products */,
+				E25CFD8E24C31F5000EBA240 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E20EC87524B0639E006C9FB8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E20EC87424B0639E006C9FB8 /* CloudStorage-iOS13.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E20EC87624B0639E006C9FB8 /* CloudStorage-iOS13 */ = {
+			isa = PBXGroup;
+			children = (
+				E25CFD9124C322B200EBA240 /* Resources */,
+				E20EC87F24B0639E006C9FB8 /* Preview Content */,
+				E20EC87B24B0639E006C9FB8 /* ContentView.swift */,
+				764AAB622827E82600717087 /* CloudSettings.swift */,
+				E25CFD8924C2EE5000EBA240 /* MyColor.swift */,
+				E25CFD9224C3242D00EBA240 /* CloudStorage+Codable.swift */,
+			);
+			path = "CloudStorage-iOS13";
+			sourceTree = "<group>";
+		};
+		E20EC87F24B0639E006C9FB8 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				E20EC88024B0639E006C9FB8 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		E25CFD8E24C31F5000EBA240 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E25CFD9124C322B200EBA240 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				E22E35F724B212160023F35A /* CloudStorage-iOS13.entitlements */,
+				E20EC87724B0639E006C9FB8 /* AppDelegate.swift */,
+				E20EC87924B0639E006C9FB8 /* SceneDelegate.swift */,
+				E20EC87D24B0639E006C9FB8 /* Assets.xcassets */,
+				E20EC88224B0639E006C9FB8 /* LaunchScreen.storyboard */,
+				E20EC88524B0639E006C9FB8 /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E20EC87324B0639E006C9FB8 /* CloudStorage-iOS13 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E20EC88824B0639E006C9FB8 /* Build configuration list for PBXNativeTarget "CloudStorage-iOS13" */;
+			buildPhases = (
+				E20EC87024B0639E006C9FB8 /* Sources */,
+				E20EC87124B0639E006C9FB8 /* Frameworks */,
+				E20EC87224B0639E006C9FB8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "CloudStorage-iOS13";
+			packageProductDependencies = (
+				E25CFD8F24C31F5000EBA240 /* CloudStorage */,
+			);
+			productName = "CloudStorage-iOS13";
+			productReference = E20EC87424B0639E006C9FB8 /* CloudStorage-iOS13.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E20EC86C24B0639E006C9FB8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1150;
+				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+					E20EC87324B0639E006C9FB8 = {
+						CreatedOnToolsVersion = 11.5;
+					};
+				};
+			};
+			buildConfigurationList = E20EC86F24B0639E006C9FB8 /* Build configuration list for PBXProject "CloudStorage-iOS13" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E20EC86B24B0639E006C9FB8;
+			packageReferences = (
+			);
+			productRefGroup = E20EC87524B0639E006C9FB8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E20EC87324B0639E006C9FB8 /* CloudStorage-iOS13 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E20EC87224B0639E006C9FB8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E20EC88424B0639E006C9FB8 /* LaunchScreen.storyboard in Resources */,
+				E20EC88124B0639E006C9FB8 /* Preview Assets.xcassets in Resources */,
+				E20EC87E24B0639E006C9FB8 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E20EC87024B0639E006C9FB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E20EC87824B0639E006C9FB8 /* AppDelegate.swift in Sources */,
+				E20EC87A24B0639E006C9FB8 /* SceneDelegate.swift in Sources */,
+				764AAB632827E82600717087 /* CloudSettings.swift in Sources */,
+				E25CFD9324C3242D00EBA240 /* CloudStorage+Codable.swift in Sources */,
+				E20EC87C24B0639E006C9FB8 /* ContentView.swift in Sources */,
+				E25CFD8A24C2EE5000EBA240 /* MyColor.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		E20EC88224B0639E006C9FB8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E20EC88324B0639E006C9FB8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E20EC88624B0639E006C9FB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E20EC88724B0639E006C9FB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E20EC88924B0639E006C9FB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "CloudStorage-iOS13/Resources/CloudStorage-iOS13.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"CloudStorage-iOS13/Preview Content\"";
+				DEVELOPMENT_TEAM = VFBLFL665K;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = NO;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "CloudStorage-iOS13/Resources/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.CloudStorage-iOS13";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E20EC88A24B0639E006C9FB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "CloudStorage-iOS13/Resources/CloudStorage-iOS13.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"CloudStorage-iOS13/Preview Content\"";
+				DEVELOPMENT_TEAM = VFBLFL665K;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = NO;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "CloudStorage-iOS13/Resources/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.CloudStorage-iOS13";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E20EC86F24B0639E006C9FB8 /* Build configuration list for PBXProject "CloudStorage-iOS13" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E20EC88624B0639E006C9FB8 /* Debug */,
+				E20EC88724B0639E006C9FB8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E20EC88824B0639E006C9FB8 /* Build configuration list for PBXNativeTarget "CloudStorage-iOS13" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E20EC88924B0639E006C9FB8 /* Debug */,
+				E20EC88A24B0639E006C9FB8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E25CFD8F24C31F5000EBA240 /* CloudStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CloudStorage;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E20EC86C24B0639E006C9FB8 /* Project object */;
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/CloudSettings.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/CloudSettings.swift
@@ -1,0 +1,24 @@
+//
+//  CloudSettings.swift
+//  CloudStorage-iOS13
+//
+//  Created by Yang Xu on 2022/5/8
+//  Copyright © 2022 Yang Xu. All rights reserved.
+//
+//  Follow me on Twitter: @fatbobman
+//  My Blog: https://www.fatbobman.com
+//
+
+import CloudStorage
+import Combine
+import Foundation
+
+class CloudSettings: ObservableObject {
+    @CloudStorage("readyForAction") var readyForAction = false
+    @CloudStorage("speed") var speed: Double = 0
+    @CloudStorage("numberOfItems") var numberOfItems = 0
+    @CloudStorage("ninjaTurtle") var ninjaTurtle = turtles[0]
+    @CloudStorage("orientation") var orientation: String?
+    @CloudStorage("favoriteColor") var favoriteColor = MyColor(.lightGray)
+    @CloudStorage("planets") var planets: [String] = terrestrialPlanets
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/CloudStorage+Codable.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/CloudStorage+Codable.swift
@@ -1,0 +1,38 @@
+//
+//  CloudStorage+Codable.swift
+//  CloudStorage-iOS13
+//
+//  Created by Tom Lokhorst on 2020-07-18.
+//
+
+import Foundation
+import CloudStorage
+
+private let sync = CloudStorageSync.shared
+
+extension CloudStorage where Value: Codable {
+    public init(wrappedValue: Value, _ key: String) {
+        self.init(
+            keyName: key,
+            syncGet: {
+                guard let data = sync.data(for: key) else { return wrappedValue }
+                do {
+                    let decoder = PropertyListDecoder()
+                    let value = try decoder.decode(Value.self, from: data)
+                    return value
+                } catch {
+                    assertionFailure("\(error)")
+                    return wrappedValue
+                }
+            },
+            syncSet: { newValue in
+                do {
+                    let encoder = PropertyListEncoder()
+                    let data = try encoder.encode(newValue)
+                    sync.set(data, for: key)
+                } catch {
+                    assertionFailure("\(error)")
+                }
+            })
+    }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/ContentView.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/ContentView.swift
@@ -1,0 +1,127 @@
+//
+//  ContentView.swift
+//  CloudStorage-iOS13
+//
+//  Created by Tom Lokhorst on 2020-07-04.
+//
+
+import SwiftUI
+import CloudStorage
+
+let turtles: [String] = [
+    "Leonardo", "Michelangelo",
+    "Donatello", "Raphael" ]
+let terrestrialPlanets: [String] = [
+    "Mercury", "Venus", "Earth", "Mars",
+].sorted()
+
+struct ContentView: View {
+    @ObservedObject var cloudStorageSync = CloudStorageSync.shared
+
+    @StateObject var settings = CloudSettings()
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                VStack(alignment: .leading) {
+                    Text("CloudStorageSync status:")
+                    Text(cloudStorageSync.status.description).font(.caption)
+                }
+                    .padding()
+                    .background(Color(UIColor.secondarySystemBackground))
+
+                Group {
+                    Toggle(isOn: $settings.readyForAction) {
+                        Text("Ready for action")
+                    }
+                    HStack(spacing: 20) {
+                        Text("Speed (km/h)")
+                        Slider(value: $settings.speed, in: 0...200)
+                    }
+                    Button("Set average speed") {
+                        self.settings.speed = 100
+                    }
+
+                    Stepper("Number of items: \(settings.numberOfItems)", value: $settings.numberOfItems, in: 0...5)
+
+                    Picker("Ninja Turtle", selection: $settings.ninjaTurtle) {
+                        ForEach(turtles, id: \.self) { turtle in
+                            Text("\(turtle)")
+                        }
+                    }
+                    HStack {
+                        Text("Orientation")
+                        Spacer()
+                        Text(settings.orientation ?? "")
+                    }
+                    HStack {
+                        Spacer()
+                        Button("Left") { self.settings.orientation = "Left" }
+                        Spacer()
+                        Button("Right") { self.settings.orientation = "Right" }
+                        Spacer()
+                        Button("[Clear]") { self.settings.orientation = nil }
+                    }
+                }
+
+                Group {
+                    HStack {
+                        Text("Favorite color")
+                        Spacer()
+                        Rectangle()
+                            .fill(Color(settings.favoriteColor))
+                            .frame(width: 80, height: 30)
+                            .border(Color(UIColor.separator), width: 1)
+                            .onDrag { NSItemProvider(object: self.settings.favoriteColor.uiColor) }
+                    }
+                    .onDrop(
+                        of: ["com.apple.uikit.color"],
+                        delegate: ColorDropDelegate(color: $settings.favoriteColor)
+                    )
+
+                    Text("Terrestrial planets")
+                    List {
+                        ForEach(settings.planets, id: \.self) { planet in
+                            Text(planet)
+                        }
+                        .onMove(perform: movePlanets)
+                    }.frame(height: 140)
+                }
+            }
+            .frame(maxWidth: 720)
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func movePlanets(source: IndexSet, destination: Int) {
+        settings.planets.move(fromOffsets: source, toOffset: destination)
+    }
+}
+
+struct ColorDropDelegate: DropDelegate {
+    @Binding var color: MyColor
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard info.hasItemsConforming(to: ["com.apple.uikit.color"]) else {
+            return false
+        }
+        let providers = info.itemProviders(for: ["com.apple.uikit.color"])
+        for provider in providers {
+            provider.loadObject(ofClass: UIColor.self) { color, _ in
+                guard let color = color as? UIColor else { return }
+                DispatchQueue.main.async {
+                    self.color = MyColor(color)
+                }
+            }
+        }
+
+        return true
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/MyColor.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/MyColor.swift
@@ -1,0 +1,53 @@
+//
+//  MyColor.swift
+//  CloudStorage-iOS13
+//
+//  Created by Tom Lokhorst on 2020-07-18.
+//
+
+import SwiftUI
+
+// Note: This example is not for production use.
+// This ignores color space, forces 8-bit sRGB
+struct MyColor: RawRepresentable {
+    var rawValue: Int
+
+    init(_ uiColor: UIColor) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        let r = Int(red * 255)
+        let g = Int(green * 255)
+        let b = Int(blue * 255)
+        let a = Int(alpha * 255)
+
+        rawValue = (r << 24) | (g << 16) | (b << 8) | a
+    }
+
+    init?(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    var uiColor: UIColor {
+        let r = (rawValue >> 24) & 0xff
+        let g = (rawValue >> 16) & 0xff
+        let b = (rawValue >> 8) & 0xff
+        let a = rawValue & 0xff
+
+        return UIColor(
+            red: CGFloat(r) / 255,
+            green: CGFloat(g) / 255,
+            blue: CGFloat(b) / 255,
+            alpha: CGFloat(a) / 255)
+    }
+}
+
+extension Color {
+    init(_ myColor: MyColor) {
+        self.init(myColor.uiColor)
+    }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/AppDelegate.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  CloudStorage-iOS13
+//
+//  Created by Tom Lokhorst on 2020-07-04.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Assets.xcassets/Contents.json
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/CloudStorage-iOS13.entitlements
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/CloudStorage-iOS13.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array/>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Info.plist
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/SceneDelegate.swift
+++ b/Examples/CloudStorageInObservableObject-iOS13/CloudStorage-iOS13/Resources/SceneDelegate.swift
@@ -1,0 +1,63 @@
+//
+//  SceneDelegate.swift
+//  CloudStorage-iOS13
+//
+//  Created by Tom Lokhorst on 2020-07-04.
+//
+
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+
+        // Create the SwiftUI view that provides the window contents.
+        let contentView = ContentView()
+
+        // Use a UIHostingController as window root view controller.
+        if let windowScene = scene as? UIWindowScene {
+            let window = UIWindow(windowScene: windowScene)
+            window.rootViewController = UIHostingController(rootView: contentView)
+            self.window = window
+            window.makeKeyAndVisible()
+        }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+


### PR DESCRIPTION
Hi, thanks for sharing the CloudStorage library!

In SwiftUI, I often integrate @AppStorage into a class to make it easier to manage. For example.
```swift
class Settings:ObservableObject {
       @AppStorage("name") var name = "fat"
       @AppStorage("age") var age = 5
}
```

This is possible because @AppStorage implements a @Published-like behavior pattern by default, calling ObservableObject's objectWillChange when it is about to change 

For implementation principles see.
[Referencing the enclosing 'self' in a wrapper type](https://github.com/apple/swift-evolution/blob/main/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type)

I added the above implementation to CloudStorage as well, giving CloudStorage a similar behavior to @Published. It's easy to put into a class and manage it in a unified way.

```swift
class Settings:ObservableObject {
       @AppStorage("name") var name = "fat"
       @AppStorage("age") var age = 5
       @CloudStorage("readyForAction") var readyForAction = false
       @CloudStorage("speed") var speed: Double = 0
}
```

In addition, I cloned the CloudStorage-iOS13 project in examples and modified it to use a unified management form.
