### PR TITLE
Fixes #12 : Prepare CloudStorage for Swift 6 Language mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ DerivedData
 *.ipa
 *.xcuserstate
 .build
+.swiftpm

--- a/Sources/CloudStorage/CloudStorage.swift
+++ b/Sources/CloudStorage/CloudStorage.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 import Combine
 
-private let sync = CloudStorageSync.shared
+@MainActor private let sync = CloudStorageSync.shared
 
-@propertyWrapper public struct CloudStorage<Value>: DynamicProperty {
+@propertyWrapper
+@MainActor
+public struct CloudStorage<Value>: DynamicProperty {
     @ObservedObject private var object: CloudStorageObject<Value>
 
     public var wrappedValue: Value {
@@ -41,7 +43,7 @@ private let sync = CloudStorageSync.shared
     }
 }
 
-internal class KeyObserver {
+@MainActor internal class KeyObserver {
     weak var storageObjectWillChange: ObservableObjectPublisher?
     weak var enclosingObjectWillChange: ObservableObjectPublisher?
 
@@ -78,7 +80,9 @@ internal class CloudStorageObject<Value>: ObservableObject {
     }
 
     deinit {
-        sync.removeObserver(keyObserver)
+        Task { @MainActor [keyObserver] in
+            sync.removeObserver(keyObserver)
+        }
     }
 }
 

--- a/Sources/CloudStorage/CloudStorageSync.swift
+++ b/Sources/CloudStorage/CloudStorageSync.swift
@@ -11,8 +11,8 @@ import Combine
 #if canImport(UIKit)
 import UIKit
 #endif
-
-public class CloudStorageSync: ObservableObject {
+@MainActor
+public final class CloudStorageSync: ObservableObject {
     public static let shared = CloudStorageSync()
 
     private let ubiquitousKvs: NSUbiquitousKeyValueStore


### PR DESCRIPTION
This PR fixes #12 by preparing CloudStorage for the Swift 6 language mode. It adds main actor isolation where necessary.

**Possible backwards compatibility issues**
Every class/struct that uses the CloudStorage property wrapper needs to be isolated to the MainActor. For iOS 18+, this is the standard for SwiftUI Views and issues with this change are minimal, so the impact of this PR should also have little impact on pre Swift 6 code. 

I did a quick test and the functionality shouldn't be affected.