### PR TITLE
Dispatch KVS notifications to MainActor context

### DIFF
--- a/Sources/CloudStorage/CloudStorageSync.swift
+++ b/Sources/CloudStorage/CloudStorageSync.swift
@@ -31,7 +31,7 @@ public final class CloudStorageSync: ObservableObject {
             queue: .main
         ) { [weak self] notification in
             guard let self else { return }
-            DispatchQueue.main.async {
+            MainActor.assumeIsolated {
                 self.didChangeExternally(notification: notification)
             }
         }
@@ -46,7 +46,7 @@ public final class CloudStorageSync: ObservableObject {
         #endif
     }
 
-    @objc private func didChangeExternally(notification: Notification) {
+     private func didChangeExternally(notification: Notification) {
         let reasonRaw = notification.userInfo?[NSUbiquitousKeyValueStoreChangeReasonKey] as? Int ?? -1
         let keys = notification.userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String] ?? []
         let reason = ChangeReason(rawValue: reasonRaw)

--- a/Sources/CloudStorage/CloudStorageSync.swift
+++ b/Sources/CloudStorage/CloudStorageSync.swift
@@ -26,10 +26,15 @@ public final class CloudStorageSync: ObservableObject {
         status = Status(date: Date(), source: .initial, keys: [])
 
         NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didChangeExternally(notification:)),
-            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
-            object: nil)
+            forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                self.didChangeExternally(notification: notification)
+            }
+        }
         ubiquitousKvs.synchronize()
 
         #if canImport(UIKit) && !os(watchOS)

--- a/Sources/CloudStorage/CloudStorageSync.swift
+++ b/Sources/CloudStorage/CloudStorageSync.swift
@@ -46,7 +46,7 @@ public final class CloudStorageSync: ObservableObject {
         #endif
     }
 
-     private func didChangeExternally(notification: Notification) {
+    private func didChangeExternally(notification: Notification) {
         let reasonRaw = notification.userInfo?[NSUbiquitousKeyValueStoreChangeReasonKey] as? Int ?? -1
         let keys = notification.userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String] ?? []
         let reason = ChangeReason(rawValue: reasonRaw)


### PR DESCRIPTION
This PR fixes #14 by ensuring proper MainActor isolation in KVS notification handling.

The original functionality should not be affected.

I've done basic testing and verified that the basic functionality continues to work as expected.



