### PR TITLE
opt: update creating of Binding for projectedValue of CloudStorage

### DIFF
--- a/Sources/CloudStorage/CloudStorage.swift
+++ b/Sources/CloudStorage/CloudStorage.swift
@@ -21,7 +21,7 @@ public struct CloudStorage<Value>: DynamicProperty {
     }
 
     public var projectedValue: Binding<Value> {
-        Binding { object.value } set: { object.value = $0 }
+        $object.value
     }
 
     public init(keyName key: String, syncGet: @escaping () -> Value, syncSet: @escaping (Value) -> Void) {


### PR DESCRIPTION
based on the discussion about [A better way to create SwiftUI bindings](https://www.pointfree.co/clips/992082116) by point free, It's better to use KeyPath subscript to retrieve a Binding from the object instead of `init(get:set:)` initializer.

Behaviors should act the same.