### PR TITLE
Add Codable and Dictionary support to CloudStorage property wrapper

### DIFF
--- a/Sources/CloudStorage/CloudStorage.swift
+++ b/Sources/CloudStorage/CloudStorage.swift
@@ -251,3 +251,31 @@ extension CloudStorage {
             syncSet: { newValue in sync.set(newValue, for: key) })
     }
 }
+
+extension CloudStorage where Value: Codable {
+    public init(wrappedValue: Value, _ key: String) {
+        self.init(
+            keyName: key,
+            syncGet: {
+                guard let data = sync.data(for: key) else {
+                    return wrappedValue
+                }
+                do {
+                    let value = try JSONDecoder().decode(Value.self, from: data)
+                    return value
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                    return wrappedValue
+                }
+            },
+            syncSet: { newValue in
+                do {
+                    let data = try JSONEncoder().encode(newValue)
+                    sync.set(data, for: key)
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+        )
+    }
+}

--- a/Sources/CloudStorage/CloudStorage.swift
+++ b/Sources/CloudStorage/CloudStorage.swift
@@ -279,3 +279,31 @@ extension CloudStorage where Value: Codable {
         )
     }
 }
+
+extension CloudStorage {
+    public init<T>(wrappedValue: Value, _ key: String) where Value == Dictionary<String, T>, T: Codable {
+        self.init(
+            keyName: key,
+            syncGet: {
+                guard let data = sync.data(for: key) else {
+                    return wrappedValue
+                }
+                do {
+                    let value = try JSONDecoder().decode(Value.self, from: data)
+                    return value
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                    return wrappedValue
+                }
+            },
+            syncSet: { newValue in
+                do {
+                    let data = try JSONEncoder().encode(newValue)
+                    sync.set(data, for: key)
+                } catch {
+                    assertionFailure(error.localizedDescription)
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
**PR Description:**
This PR enhances the CloudStorage property wrapper by adding support for:
1. **Generic Codable values**
Allows seamless persistence of any type conforming to Codable.
2. **Dictionaries with String keys and Codable values**
Enables storing [String: T] dictionaries, where T: Codable, making it easy to persist maps of structured data.

**Implementation details:**
- New initializer for CloudStorage<Value> where Value: Codable
- New initializer for CloudStorage<Value> where Value == [String: V] and V: Codable
- Both initializers gracefully fall back to wrappedValue if data is missing or decoding fails
- Errors are surfaced via assertionFailure to aid debugging

These changes provide better support for complex and nested value types in cloud-backed user settings or app state.